### PR TITLE
parameterize for other platforms

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,18 @@ const argv = require('yargs')
     demandOption: true,
     describe: 'electron version',
   })
+  .option('platform', {
+    alias: 'p',
+    demandOption: true,
+    describe: 'platform',
+    choices: ['darwin', 'win32', 'linux', 'mas'],
+  })
+  .option('arch', {
+    alias: 'a',
+    demandOption: true,
+    describe: 'architecture',
+    choices: ['ia32', 'x64', 'arm64', 'armv7l']
+  })
   .option('quiet', {
     alias: 'q',
     describe: 'suppress download progress output',

--- a/index.js
+++ b/index.js
@@ -5,11 +5,10 @@ const electronDownload = require('electron-download')
 const extractZip = require('extract-zip')
 
 const electronMinidump = async (options) => {
-  const {version, quiet, force, file} = options
-  const platform = 'win32'
+  const {version, quiet, force, file, platform, arch} = options
   const directory = path.join(__dirname, 'cache', version + '-' + platform)
 
-  await download({version, quiet, directory, platform, force})
+  await download({version, quiet, directory, platform, force, arch})
 
   const symbolPaths = [
     path.join(directory, 'breakpad_symbols'),
@@ -26,13 +25,13 @@ const electronMinidump = async (options) => {
 
 const download = (options) => {
   return new Promise((resolve, reject) => {
-    const {version, quiet, directory, platform, force} = options
+    const {version, quiet, directory, platform, force, arch} = options
 
     if (fs.existsSync(directory) && !force) return resolve()
 
     electronDownload({
       platform,
-      arch: 'x64',
+      arch,
       version,
       symbols: true,
       quiet,


### PR DESCRIPTION
Support other platforms https://github.com/nornagon/electron-minidump/issues/1

I didn't add any validation that the right combination of platform + arch was used. I assume the error that `electron-download` throws is enough ¯\_(ツ)_/¯ 